### PR TITLE
🌲: Annotate pure functions with `@__NO_SIDE_EFFECTS__` to enable better tree-shaking.

### DIFF
--- a/packages/typed-binary/package.json
+++ b/packages/typed-binary/package.json
@@ -1,6 +1,7 @@
 {
   "name": "typed-binary",
   "version": "4.3.1",
+  "sideEffects": false,
   "description": "Describe binary structures with full TypeScript support. Encode and decode into pure JavaScript objects.",
   "packageManager": "pnpm@8.15.8+sha256.691fe176eea9a8a80df20e4976f3dfb44a04841ceb885638fe2a26174f81e65e",
   "type": "module",

--- a/packages/typed-binary/src/io/unwrapBuffer.ts
+++ b/packages/typed-binary/src/io/unwrapBuffer.ts
@@ -7,6 +7,7 @@ interface UnwrapBufferResult {
 /**
  * Removes up to one layer of view over a buffer.
  */
+// @__NO_SIDE_EFFECTS__
 export function unwrapBuffer(
   buffer: ArrayBufferLike | ArrayBufferView,
 ): UnwrapBufferResult {

--- a/packages/typed-binary/src/structure/array.ts
+++ b/packages/typed-binary/src/structure/array.ts
@@ -82,6 +82,7 @@ export class ArraySchema<TElement extends AnySchema> extends Schema<
   }
 }
 
+// @__NO_SIDE_EFFECTS__
 export function arrayOf<TSchema extends AnySchema>(
   elementSchema: TSchema,
   length: number,

--- a/packages/typed-binary/src/structure/chars.ts
+++ b/packages/typed-binary/src/structure/chars.ts
@@ -37,6 +37,7 @@ export class CharsSchema<
   }
 }
 
+// @__NO_SIDE_EFFECTS__
 export function chars<T extends number>(length: T): CharsSchema<T> {
   return new CharsSchema(length);
 }

--- a/packages/typed-binary/src/structure/concat.ts
+++ b/packages/typed-binary/src/structure/concat.ts
@@ -6,6 +6,7 @@ type Concat<Objs extends AnyObjectSchema[]> = ObjectSchema<
   MergeRecordUnion<PropertiesOf<Objs[number]>>
 >;
 
+// @__NO_SIDE_EFFECTS__
 export function concat<Objs extends AnyObjectSchema[]>(
   objs: Objs,
 ): Concat<Objs> {

--- a/packages/typed-binary/src/structure/dynamicArray.ts
+++ b/packages/typed-binary/src/structure/dynamicArray.ts
@@ -119,6 +119,7 @@ export class DynamicArraySchema<TElement extends AnySchema> extends Schema<
   }
 }
 
+// @__NO_SIDE_EFFECTS__
 export function dynamicArrayOf<TSchema extends AnySchema>(
   elementSchema: TSchema,
 ): DynamicArraySchema<TSchema> {

--- a/packages/typed-binary/src/structure/keyed.ts
+++ b/packages/typed-binary/src/structure/keyed.ts
@@ -145,6 +145,7 @@ export class KeyedSchema<
   }
 }
 
+// @__NO_SIDE_EFFECTS__
 export function keyed<K extends string, P extends ISchema<unknown>>(
   key: K,
   inner: (ref: ISchema<Ref<K>>) => P,

--- a/packages/typed-binary/src/structure/object.ts
+++ b/packages/typed-binary/src/structure/object.ts
@@ -15,12 +15,14 @@ import {
   type UnwrapRecord,
 } from './types.ts';
 
+// @__NO_SIDE_EFFECTS__
 export function exactEntries<T extends Record<keyof T, T[keyof T]>>(
   record: T,
 ): [keyof T, T[keyof T]][] {
   return Object.entries(record) as [keyof T, T[keyof T]][];
 }
 
+// @__NO_SIDE_EFFECTS__
 export function resolveMap<T extends Record<string, AnySchema>>(
   ctx: IRefResolver,
   refs: T,
@@ -134,6 +136,7 @@ export class ObjectSchema<TProps extends Record<string, AnySchema>>
   }
 }
 
+// @__NO_SIDE_EFFECTS__
 export function object<P extends Record<string, AnySchema>>(
   properties: P,
 ): ObjectSchema<P> {
@@ -306,6 +309,7 @@ export class GenericObjectSchema<
   }
 }
 
+// @__NO_SIDE_EFFECTS__
 export function generic<
   P extends Record<string, AnySchema>,
   S extends {
@@ -315,6 +319,7 @@ export function generic<
   return new GenericObjectSchema(SubTypeKey.STRING, properties, subTypeMap);
 }
 
+// @__NO_SIDE_EFFECTS__
 export function genericEnum<
   P extends Record<string, AnySchema>,
   S extends {

--- a/packages/typed-binary/src/structure/optional.ts
+++ b/packages/typed-binary/src/structure/optional.ts
@@ -72,6 +72,7 @@ export class OptionalSchema<TInner extends AnySchema> extends Schema<
   }
 }
 
+// @__NO_SIDE_EFFECTS__
 export function optional<TSchema extends AnySchema>(
   innerType: TSchema,
 ): OptionalSchema<TSchema> {

--- a/packages/typed-binary/src/structure/tuple.ts
+++ b/packages/typed-binary/src/structure/tuple.ts
@@ -10,6 +10,7 @@ import {
   type UnwrapArray,
 } from './types.ts';
 
+// @__NO_SIDE_EFFECTS__
 export function resolveArray<T extends AnySchema[]>(
   ctx: IRefResolver,
   refs: T,
@@ -88,6 +89,7 @@ export class TupleSchema<
   }
 }
 
+// @__NO_SIDE_EFFECTS__
 export function tupleOf<TSchema extends [AnySchema, ...AnySchema[]]>(
   schemas: TSchema,
 ): TupleSchema<TSchema> {

--- a/packages/typed-binary/src/structure/typedArray.ts
+++ b/packages/typed-binary/src/structure/typedArray.ts
@@ -41,31 +41,40 @@ export class TypedArraySchema<
   }
 }
 
+// @__NO_SIDE_EFFECTS__
 export const u8Array = (length: number): TypedArraySchema<Uint8Array> =>
   new TypedArraySchema(length, Uint8Array);
 
+// @__NO_SIDE_EFFECTS__
 export const u8ClampedArray = (
   length: number,
 ): TypedArraySchema<Uint8ClampedArray> =>
   new TypedArraySchema(length, Uint8ClampedArray);
 
+// @__NO_SIDE_EFFECTS__
 export const u16Array = (length: number): TypedArraySchema<Uint16Array> =>
   new TypedArraySchema(length, Uint16Array);
 
+// @__NO_SIDE_EFFECTS__
 export const u32Array = (length: number): TypedArraySchema<Uint32Array> =>
   new TypedArraySchema(length, Uint32Array);
 
+// @__NO_SIDE_EFFECTS__
 export const i8Array = (length: number): TypedArraySchema<Int8Array> =>
   new TypedArraySchema(length, Int8Array);
 
+// @__NO_SIDE_EFFECTS__
 export const i16Array = (length: number): TypedArraySchema<Int16Array> =>
   new TypedArraySchema(length, Int16Array);
 
+// @__NO_SIDE_EFFECTS__
 export const i32Array = (length: number): TypedArraySchema<Int32Array> =>
   new TypedArraySchema(length, Int32Array);
 
+// @__NO_SIDE_EFFECTS__
 export const f32Array = (length: number): TypedArraySchema<Float32Array> =>
   new TypedArraySchema(length, Float32Array);
 
+// @__NO_SIDE_EFFECTS__
 export const f64Array = (length: number): TypedArraySchema<Float64Array> =>
   new TypedArraySchema(length, Float64Array);

--- a/packages/typed-binary/src/util.ts
+++ b/packages/typed-binary/src/util.ts
@@ -1,6 +1,7 @@
 /**
  * @returns {Boolean} true if system is big endian
  */
+// @__NO_SIDE_EFFECTS__
 function isSystemBigEndian(): boolean {
   const array = new Uint8Array(4);
   const view = new Uint32Array(array.buffer);
@@ -10,6 +11,7 @@ function isSystemBigEndian(): boolean {
   return array[0] === 0; // if zero is the left-most byte, one was encoded as big endian
 }
 
+// @__NO_SIDE_EFFECTS__
 export function getSystemEndianness(): 'big' | 'little' {
   return isSystemBigEndian() ? 'big' : 'little';
 }


### PR DESCRIPTION
Context: https://github.com/javascript-compiler-hints/compiler-notations-spec/blob/main/no-side-effects-notation-spec.md